### PR TITLE
suppression du npm start dans le workflows

### DIFF
--- a/.github/workflows/master_lazythebot.yml
+++ b/.github/workflows/master_lazythebot.yml
@@ -37,10 +37,4 @@ jobs:
         app-name: 'lazythebot'
         slot-name: 'production'
         publish-profile: ${{ secrets.AzureAppService_PublishProfile_7f4e97b56bac4423a85b658e5befc4e3 }}
-        package: .
-
-    - name: npm start
-      env:
-        token: ${{ secrets.TOKEN }}
-      run:
-        npm run start      
+        package: .     


### PR DESCRIPTION
le npm start bloquer le déploiement et fesais tourner le bot uniquement dans le github action